### PR TITLE
data abstraction and abstract syntax workshop implemented

### DIFF
--- a/first-workshop.rkt
+++ b/first-workshop.rkt
@@ -1,8 +1,6 @@
-; Taller # 1 - Recursion
-;
 ; Gabriela Guzmán 2326772-3743
 ; Valentina Sanchéz 2324754-3743
-; Juan Pablo Moreno COD
+; Juan Pablo Moreno 2372232-3743
 
 #lang eopl
 
@@ -15,59 +13,42 @@
         (cons (list (car l)) (down (cdr l))))))
 
 
-;; PUNTO 1 invert 
-;; Propósito:
-;; L -> L' : Procedimiento que recibe una lista de pares y devuelve una lista con los pares invertidos.
-;;
-;; <lista> := ()
-;;         | (<par> <lista>)
-;; <par> := (<valor> <valor>)
-
+;; Punto #1 invert :
 (define invert
   (lambda (l)
     (if (null? l)
         '()  ; Caso base: lista vacía
-        (cons (list (cadr (car l)) (car (car l))) 
-              (invert (cdr l)))))) 
+        (cons (list (cadr (car l)) (car (car l)))
+              (invert (cdr l))))))
 
 ;; Pruebas
 (display (invert '((a 1) (a 2) (1 b) (2 b)))) (newline)
 (display (invert '((5 9) (10 91) (82 7) (a e) ("hola" "Mundo")))) (newline)
 (display (invert '(("es" "racket") ("genial" "muy") (17 29) (81 o)))) (newline)
 
-;; Punto #4 filter-in:
-;; Proposito:
-;; P x L -> L' : Procedimiento que filtra los elementos de L que cumplen el predicado P.
-;;
-;; <lista> := ()
-;;          := (<valor> <lista>)
+;; Punto #4 filter-in :
 
 (define filter-in
   (lambda (P L)
     (if (null? L)
-        '()  
-        (if (P (car L)) 
-            (cons (car L) (filter-in P (cdr L)))  
-            (filter-in P (cdr L)))))) 
+        '()
+        (if (P (car L))
+            (cons (car L) (filter-in P (cdr L)))
+            (filter-in P (cdr L))))))
 
-;; Pruebas: 
-(display (filter-in number? '(a 2 (1 3) b 7))) (newline)   
-(display (filter-in symbol? '(a (b c) 17 foo))) (newline)  
-(display (filter-in string? '(a b u "univalle" "racket" "flp" 28 90 (1 2 3)))) (newline)  
+;; Pruebas del profe
+(display (filter-in number? '(a 2 (1 3) b 7))) (newline)   ;  (2 7)
+(display (filter-in symbol? '(a (b c) 17 foo))) (newline)  ;  (a foo)
+(display (filter-in string? '(a b u "univalle" "racket" "flp" 28 90 (1 2 3)))) (newline)  ; ("univalle" "racket" "flp")
 
-;; Punto #7 cartesian-product:
-;; Proposito:
-;; L1 x L2 -> L' : Procedimiento que devuelve el producto cartesiano entre dos listas.
-;;
-;; <lista> := ()
-;;          := (<valor> <lista>)
+;; Punto #7 cartesian-product :
 
 (define cartesian-product
   (lambda (L1 L2)
-    (if (or (null? L1) (null? L2))  
-        '()  
-        (append (pair-with (car L1) L2)  
-                (cartesian-product (cdr L1) L2)))))  
+    (if (or (null? L1) (null? L2))
+        '()
+        (append (pair-with (car L1) L2)
+                (cartesian-product (cdr L1) L2)))))
 
 ;; Función auxiliar pair-with
 ;; Proposito:
@@ -75,26 +56,21 @@
 (define pair-with
   (lambda (x L)
     (if (null? L)
-        '()  
-        (cons (list x (car L)) (pair-with x (cdr L))))))  
+        '()
+        (cons (list x (car L)) (pair-with x (cdr L))))))
 
 ;; Pruebas
 (display (cartesian-product '(a b c) '(x y))) (newline)
 (display (cartesian-product '(p q r) '(5 6 7))) (newline)
 (display (cartesian-product '(1 2) '(a b c d))) (newline)
 
-;; Punto #10 up :
-;; Proposito:
-;; L -> L' : Procedimiento que remueve un nivel de paréntesis de la lista dada.
-;;
-;; <lista> := ()
-;;          := (<valor> <lista>)
+;; Punto 10 up :
 (define up
   (lambda (L)
     (if (null? L)
-        '()  
-        (append (unpack (car L))  
-                (up (cdr L))))))  
+        '()
+        (append (unpack (car L))
+                (up (cdr L))))))
 
 ;; Función auxiliar unpack
 ;; Proposito:
@@ -102,71 +78,56 @@
 (define unpack
   (lambda (x)
     (if (list? x)
-        x 
-        (list x))))  
+        x
+        (list x))))
 
 ;; Pruebas
-(display (up '((1 2) (3 4)))) (newline) 
-(display (up '((x (y)) z))) (newline)   
-(display (up '(((a b)) (c d) e))) (newline) 
-(display (up '((p) q ((r s))))) (newline)  
+(display (up '((1 2) (3 4)))) (newline)  ; prueba del profesor (1 2 3 4) 
+(display (up '((x (y)) z))) (newline)   ; prueba del profesor (x (y) z)
+(display (up '(((a b)) (c d) e))) (newline)  ; mi prueba ((a b) c d e)
+(display (up '((p) q ((r s))))) (newline)  ; mi prueba (p q (r s))
 
-;; Punto #13 operate :
-;; Proposito:
-;; L_ops x L_nums -> num : Procedimiento que aplica operaciones en secuencia a los números.
-;;
-;; <lista> := ()
-;;          := (<valor> <lista>)
+;; Punto 13 operate :
 (define (operate operaciones numeros)
-  (if (null? operaciones) 
-      (car numeros) 
-      (operate (cdr operaciones) 
-               (cons ((car operaciones) (car numeros) (cadr numeros)) 
+  (if (null? operaciones)
+      (car numeros)
+      (operate (cdr operaciones)
+               (cons ((car operaciones) (car numeros) (cadr numeros))
                      (cddr numeros)))))
 ;; Pruebas
 (display (operate (list + * + - *) '(1 2 8 4 11 6))) (newline) 
 (display (operate (list *) '(4 5))) (newline)  
 (display (operate (list + - * /) '(10 5 2 4 2))) (newline)
 
-;; Punto #16 Operar-binarias :
-;; Proposito:
-;; OperacionB -> num : Procedimiento que evalúa expresiones binarias.
-;;
-;; <OperacionB> := <int>
-;;              := (<OperacionB> 'suma <OperacionB>)
-;;              := (<OperacionB> 'resta <OperacionB>)
-;;              := (<OperacionB> 'multiplica <OperacionB>)
-
-;; Función auxiliar my-length
-;; Proposito:
-;; L -> num : Procedimiento que devuelve la longitud de una lista.
+;; Punto 16 Operar-binarias :
+;; Definición de  Funcion auxiliar my-length para contar los elementos de una lista
 (define my-length
   (lambda (lst)
-    (if (null? lst)  
-        0  
+    (if (null? lst)
+        0
         (+ 1 (my-length (cdr lst))))))
 
 ;; Definición de Operar-binarias
 (define Operar-binarias
   (lambda (operacionB)
     (cond
-      ((number? operacionB) operacionB)  
+      ((number? operacionB) operacionB)
       ((and (list? operacionB) (= (my-length operacionB) 3))
-       (let ((izq (Operar-binarias (car operacionB)))  
-             (op (cadr operacionB))  
-             (der (Operar-binarias (caddr operacionB))))  
+       (let ((izq (Operar-binarias (car operacionB)))
+             (op (cadr operacionB))
+             (der (Operar-binarias (caddr operacionB))))
          (cond
            ((eqv? op 'suma) (+ izq der))
            ((eqv? op 'resta) (- izq der))
            ((eqv? op 'multiplica) (* izq der))
-           (else 'operador-invalido))))  
-      (else 'expresion-invalida))))  
+           (else 'operador-invalido))))
+      (else 'expresion-invalida))))
 
       ;; Pruebas
-(display (Operar-binarias 4)) (newline)  
-(display (Operar-binarias '(2 suma 9))) (newline)  
-(display (Operar-binarias '(2 resta 9))) (newline)  
-(display (Operar-binarias '(2 multiplica 9))) (newline)  
-(display (Operar-binarias '((2 multiplica 3) suma (5 resta 1)))) (newline)  
-(display (Operar-binarias '((2 multiplica (4 suma 1)) multiplica ((2 multiplica 4) resta 1)))) (newline)  
-(display (Operar-binarias '(2 divide 3)))  
+(display (Operar-binarias 4)) (newline)  ; -> 4
+(display (Operar-binarias '(2 suma 9))) (newline)  ; -> 11
+(display (Operar-binarias '(2 resta 9))) (newline)  ; -> -7
+(display (Operar-binarias '(2 multiplica 9))) (newline)  ; -> 18
+(display (Operar-binarias '((2 multiplica 3) suma (5 resta 1)))) (newline)  ; -> 10
+(display (Operar-binarias '((2 multiplica (4 suma 1)) multiplica ((2 multiplica 4) resta 1)))) (newline)  ; -> 70
+(display (Operar-binarias '(2 divide 3)))  ; → 'operador-invalido)

--- a/first-workshop.rkt
+++ b/first-workshop.rkt
@@ -6,8 +6,23 @@
 
 #lang eopl
 
+;  point 2
 
-;; Punto #1 invert :
+(define down
+  (lambda (l)
+    (if (null? l)
+        (list)
+        (cons (list (car l)) (down (cdr l))))))
+
+
+;; PUNTO 1 invert 
+;; Propósito:
+;; L -> L' : Procedimiento que recibe una lista de pares y devuelve una lista con los pares invertidos.
+;;
+;; <lista> := ()
+;;         | (<par> <lista>)
+;; <par> := (<valor> <valor>)
+
 (define invert
   (lambda (l)
     (if (null? l)
@@ -20,7 +35,12 @@
 (display (invert '((5 9) (10 91) (82 7) (a e) ("hola" "Mundo")))) (newline)
 (display (invert '(("es" "racket") ("genial" "muy") (17 29) (81 o)))) (newline)
 
-;; Punto #4 filter-in :
+;; Punto #4 filter-in:
+;; Proposito:
+;; P x L -> L' : Procedimiento que filtra los elementos de L que cumplen el predicado P.
+;;
+;; <lista> := ()
+;;          := (<valor> <lista>)
 
 (define filter-in
   (lambda (P L)
@@ -30,12 +50,17 @@
             (cons (car L) (filter-in P (cdr L)))  
             (filter-in P (cdr L)))))) 
 
-;; Pruebas del profe
-(display (filter-in number? '(a 2 (1 3) b 7))) (newline)   ;  (2 7)
-(display (filter-in symbol? '(a (b c) 17 foo))) (newline)  ;  (a foo)
-(display (filter-in string? '(a b u "univalle" "racket" "flp" 28 90 (1 2 3)))) (newline)  ; ("univalle" "racket" "flp")
+;; Pruebas: 
+(display (filter-in number? '(a 2 (1 3) b 7))) (newline)   
+(display (filter-in symbol? '(a (b c) 17 foo))) (newline)  
+(display (filter-in string? '(a b u "univalle" "racket" "flp" 28 90 (1 2 3)))) (newline)  
 
-;; Punto #7 cartesian-product :
+;; Punto #7 cartesian-product:
+;; Proposito:
+;; L1 x L2 -> L' : Procedimiento que devuelve el producto cartesiano entre dos listas.
+;;
+;; <lista> := ()
+;;          := (<valor> <lista>)
 
 (define cartesian-product
   (lambda (L1 L2)
@@ -45,6 +70,8 @@
                 (cartesian-product (cdr L1) L2)))))  
 
 ;; Función auxiliar pair-with
+;; Proposito:
+;; x x L -> L' : Procedimiento que combina un valor con cada elemento de la lista.
 (define pair-with
   (lambda (x L)
     (if (null? L)
@@ -56,7 +83,12 @@
 (display (cartesian-product '(p q r) '(5 6 7))) (newline)
 (display (cartesian-product '(1 2) '(a b c d))) (newline)
 
-;; Punto 10 up :
+;; Punto #10 up :
+;; Proposito:
+;; L -> L' : Procedimiento que remueve un nivel de paréntesis de la lista dada.
+;;
+;; <lista> := ()
+;;          := (<valor> <lista>)
 (define up
   (lambda (L)
     (if (null? L)
@@ -64,7 +96,9 @@
         (append (unpack (car L))  
                 (up (cdr L))))))  
 
-;; Función auxiliar unpack 
+;; Función auxiliar unpack
+;; Proposito:
+;; x -> L' : Procedimiento que devuelve la lista si x es lista, o lo envuelve en una.
 (define unpack
   (lambda (x)
     (if (list? x)
@@ -72,12 +106,17 @@
         (list x))))  
 
 ;; Pruebas
-(display (up '((1 2) (3 4)))) (newline)  ; prueba del profesor (1 2 3 4) 
-(display (up '((x (y)) z))) (newline)   ; prueba del profesor (x (y) z)
-(display (up '(((a b)) (c d) e))) (newline)  ; mi prueba ((a b) c d e)
-(display (up '((p) q ((r s))))) (newline)  ; mi prueba (p q (r s))
+(display (up '((1 2) (3 4)))) (newline) 
+(display (up '((x (y)) z))) (newline)   
+(display (up '(((a b)) (c d) e))) (newline) 
+(display (up '((p) q ((r s))))) (newline)  
 
-;; Punto 13 operate :
+;; Punto #13 operate :
+;; Proposito:
+;; L_ops x L_nums -> num : Procedimiento que aplica operaciones en secuencia a los números.
+;;
+;; <lista> := ()
+;;          := (<valor> <lista>)
 (define (operate operaciones numeros)
   (if (null? operaciones) 
       (car numeros) 
@@ -85,12 +124,22 @@
                (cons ((car operaciones) (car numeros) (cadr numeros)) 
                      (cddr numeros)))))
 ;; Pruebas
-(display (operate (list + * + - *) '(1 2 8 4 11 6))) (newline)  ; -> 102
-(display (operate (list *) '(4 5))) (newline)  ; -> 20
-(display (operate (list + - * /) '(10 5 2 4 2))) (newline)  ; -> 6
+(display (operate (list + * + - *) '(1 2 8 4 11 6))) (newline) 
+(display (operate (list *) '(4 5))) (newline)  
+(display (operate (list + - * /) '(10 5 2 4 2))) (newline)
 
-;; Punto 16 Operar-binarias :
-;; Definición de  Funcion auxiliar my-length para contar los elementos de una lista
+;; Punto #16 Operar-binarias :
+;; Proposito:
+;; OperacionB -> num : Procedimiento que evalúa expresiones binarias.
+;;
+;; <OperacionB> := <int>
+;;              := (<OperacionB> 'suma <OperacionB>)
+;;              := (<OperacionB> 'resta <OperacionB>)
+;;              := (<OperacionB> 'multiplica <OperacionB>)
+
+;; Función auxiliar my-length
+;; Proposito:
+;; L -> num : Procedimiento que devuelve la longitud de una lista.
 (define my-length
   (lambda (lst)
     (if (null? lst)  
@@ -114,10 +163,10 @@
       (else 'expresion-invalida))))  
 
       ;; Pruebas
-(display (Operar-binarias 4)) (newline)  ; -> 4
-(display (Operar-binarias '(2 suma 9))) (newline)  ; -> 11
-(display (Operar-binarias '(2 resta 9))) (newline)  ; -> -7
-(display (Operar-binarias '(2 multiplica 9))) (newline)  ; -> 18
-(display (Operar-binarias '((2 multiplica 3) suma (5 resta 1)))) (newline)  ; -> 10
-(display (Operar-binarias '((2 multiplica (4 suma 1)) multiplica ((2 multiplica 4) resta 1)))) (newline)  ; -> 70
-(display (Operar-binarias '(2 divide 3)))  ; → 'operador-invalido)
+(display (Operar-binarias 4)) (newline)  
+(display (Operar-binarias '(2 suma 9))) (newline)  
+(display (Operar-binarias '(2 resta 9))) (newline)  
+(display (Operar-binarias '(2 multiplica 9))) (newline)  
+(display (Operar-binarias '((2 multiplica 3) suma (5 resta 1)))) (newline)  
+(display (Operar-binarias '((2 multiplica (4 suma 1)) multiplica ((2 multiplica 4) resta 1)))) (newline)  
+(display (Operar-binarias '(2 divide 3)))  

--- a/first-workshop.rkt
+++ b/first-workshop.rkt
@@ -1,0 +1,16 @@
+; Taller # 1 - Recursion
+;
+; Gabriela Guzmán 2326772-3743
+; Valentina Sanchéz COD
+; Juan Pablo Moreno COD
+
+#lang eopl
+
+;  point 2
+
+(define down
+  (lambda (l)
+    (if (null? l)
+        (list)
+        (cons (list (car l)) (down (cdr l))))))
+

--- a/first-workshop.rkt
+++ b/first-workshop.rkt
@@ -1,13 +1,13 @@
 ; Taller # 1 - Recursion
 ;
 ; Gabriela Guzmán 2326772-3743
-; Valentina Sanchéz COD
+; Valentina Sanchéz 2324754-3743
 ; Juan Pablo Moreno COD
 
 #lang eopl
 
-;; Punto #1 invert :
 
+;; Punto #1 invert :
 (define invert
   (lambda (l)
     (if (null? l)
@@ -19,14 +19,6 @@
 (display (invert '((a 1) (a 2) (1 b) (2 b)))) (newline)
 (display (invert '((5 9) (10 91) (82 7) (a e) ("hola" "Mundo")))) (newline)
 (display (invert '(("es" "racket") ("genial" "muy") (17 29) (81 o)))) (newline)
-
-;  point 2
-
-(define down
-  (lambda (l)
-    (if (null? l)
-        (list)
-        (cons (list (car l)) (down (cdr l))))))
 
 ;; Punto #4 filter-in :
 
@@ -63,3 +55,69 @@
 (display (cartesian-product '(a b c) '(x y))) (newline)
 (display (cartesian-product '(p q r) '(5 6 7))) (newline)
 (display (cartesian-product '(1 2) '(a b c d))) (newline)
+
+;; Punto 10 up :
+(define up
+  (lambda (L)
+    (if (null? L)
+        '()  
+        (append (unpack (car L))  
+                (up (cdr L))))))  
+
+;; Función auxiliar unpack 
+(define unpack
+  (lambda (x)
+    (if (list? x)
+        x 
+        (list x))))  
+
+;; Pruebas
+(display (up '((1 2) (3 4)))) (newline)  ; prueba del profesor (1 2 3 4) 
+(display (up '((x (y)) z))) (newline)   ; prueba del profesor (x (y) z)
+(display (up '(((a b)) (c d) e))) (newline)  ; mi prueba ((a b) c d e)
+(display (up '((p) q ((r s))))) (newline)  ; mi prueba (p q (r s))
+
+;; Punto 13 operate :
+(define (operate operaciones numeros)
+  (if (null? operaciones) 
+      (car numeros) 
+      (operate (cdr operaciones) 
+               (cons ((car operaciones) (car numeros) (cadr numeros)) 
+                     (cddr numeros)))))
+;; Pruebas
+(display (operate (list + * + - *) '(1 2 8 4 11 6))) (newline)  ; -> 102
+(display (operate (list *) '(4 5))) (newline)  ; -> 20
+(display (operate (list + - * /) '(10 5 2 4 2))) (newline)  ; -> 6
+
+;; Punto 16 Operar-binarias :
+;; Definición de  Funcion auxiliar my-length para contar los elementos de una lista
+(define my-length
+  (lambda (lst)
+    (if (null? lst)  
+        0  
+        (+ 1 (my-length (cdr lst))))))
+
+;; Definición de Operar-binarias
+(define Operar-binarias
+  (lambda (operacionB)
+    (cond
+      ((number? operacionB) operacionB)  
+      ((and (list? operacionB) (= (my-length operacionB) 3))
+       (let ((izq (Operar-binarias (car operacionB)))  
+             (op (cadr operacionB))  
+             (der (Operar-binarias (caddr operacionB))))  
+         (cond
+           ((eqv? op 'suma) (+ izq der))
+           ((eqv? op 'resta) (- izq der))
+           ((eqv? op 'multiplica) (* izq der))
+           (else 'operador-invalido))))  
+      (else 'expresion-invalida))))  
+
+      ;; Pruebas
+(display (Operar-binarias 4)) (newline)  ; -> 4
+(display (Operar-binarias '(2 suma 9))) (newline)  ; -> 11
+(display (Operar-binarias '(2 resta 9))) (newline)  ; -> -7
+(display (Operar-binarias '(2 multiplica 9))) (newline)  ; -> 18
+(display (Operar-binarias '((2 multiplica 3) suma (5 resta 1)))) (newline)  ; -> 10
+(display (Operar-binarias '((2 multiplica (4 suma 1)) multiplica ((2 multiplica 4) resta 1)))) (newline)  ; -> 70
+(display (Operar-binarias '(2 divide 3)))  ; → 'operador-invalido)

--- a/first-workshop.rkt
+++ b/first-workshop.rkt
@@ -6,6 +6,20 @@
 
 #lang eopl
 
+;; Punto #1 invert :
+
+(define invert
+  (lambda (l)
+    (if (null? l)
+        '()  ; Caso base: lista vacía
+        (cons (list (cadr (car l)) (car (car l))) 
+              (invert (cdr l)))))) 
+
+;; Pruebas
+(display (invert '((a 1) (a 2) (1 b) (2 b)))) (newline)
+(display (invert '((5 9) (10 91) (82 7) (a e) ("hola" "Mundo")))) (newline)
+(display (invert '(("es" "racket") ("genial" "muy") (17 29) (81 o)))) (newline)
+
 ;  point 2
 
 (define down
@@ -14,3 +28,38 @@
         (list)
         (cons (list (car l)) (down (cdr l))))))
 
+;; Punto #4 filter-in :
+
+(define filter-in
+  (lambda (P L)
+    (if (null? L)
+        '()  
+        (if (P (car L)) 
+            (cons (car L) (filter-in P (cdr L)))  
+            (filter-in P (cdr L)))))) 
+
+;; Pruebas del profe
+(display (filter-in number? '(a 2 (1 3) b 7))) (newline)   ;  (2 7)
+(display (filter-in symbol? '(a (b c) 17 foo))) (newline)  ;  (a foo)
+(display (filter-in string? '(a b u "univalle" "racket" "flp" 28 90 (1 2 3)))) (newline)  ; ("univalle" "racket" "flp")
+
+;; Punto #7 cartesian-product :
+
+(define cartesian-product
+  (lambda (L1 L2)
+    (if (or (null? L1) (null? L2))  
+        '()  
+        (append (pair-with (car L1) L2)  
+                (cartesian-product (cdr L1) L2)))))  
+
+;; Función auxiliar pair-with
+(define pair-with
+  (lambda (x L)
+    (if (null? L)
+        '()  
+        (cons (list x (car L)) (pair-with x (cdr L))))))  
+
+;; Pruebas
+(display (cartesian-product '(a b c) '(x y))) (newline)
+(display (cartesian-product '(p q r) '(5 6 7))) (newline)
+(display (cartesian-product '(1 2) '(a b c d))) (newline)

--- a/second-workshop/CircuitosDT.rkt
+++ b/second-workshop/CircuitosDT.rkt
@@ -1,0 +1,20 @@
+; Gabriela Guzmán 2326772-3743
+; Valentina Sanchéz 2324754-3743
+; Juan Pablo Moreno 2372232-3743
+
+; -------------------------------------------------------------------------- ;
+;                                 BNF GRAMMAR                                ;
+; -------------------------------------------------------------------------- ;
+
+; <circuit> ::= '(circuit <gatelist>)
+; <gatelist> ::= empty | <gate> <gatelist>
+; <gate> ::= '(gate <gateid> <type> <inputlist>)
+; <gateid> ::= identificador de la compuerta
+; <type> ::= and | or | not | xor
+; <inputlist> ::= empty | <bool> <inputlist>
+;               | <gateref> <inputlist>
+; <gateref> ::= identificador de otra compuerta
+
+#lang racket
+
+; datatype-based grammar implementation

--- a/second-workshop/CircuitosDT.rkt
+++ b/second-workshop/CircuitosDT.rkt
@@ -17,6 +17,8 @@
 
 #lang eopl
 
+(display "CircuitosDT.rkt cargado correctamente") (newline)
+
 ; datatype-based grammar implementation
 
 ; constructors
@@ -41,6 +43,7 @@
   (or-type)
   (not-type)
   (xor-type))
+
 
 (define-datatype input_list input_list?
   (empty-input_list)
@@ -99,3 +102,5 @@
 ; Display the circuit
 (write circuit4)
 (newline)
+
+(and-type)

--- a/second-workshop/CircuitosDT.rkt
+++ b/second-workshop/CircuitosDT.rkt
@@ -15,6 +15,87 @@
 ;               | <gateref> <inputlist>
 ; <gateref> ::= identificador de otra compuerta
 
-#lang racket
+#lang eopl
 
 ; datatype-based grammar implementation
+
+; constructors
+
+(define-datatype circuit circuit?
+  (a-circuit
+   (gate_list gate_list?)))
+
+(define-datatype gate_list gate_list?
+  (empty-gate_list)
+  (nonempty-gate_list
+   (gate gate?)
+   (rest gate_list?)))
+
+(define-datatype gate gate?
+  (a-gate (gate_id symbol?)
+          (type type?)
+          (input_list input_list?)))
+
+(define-datatype type type?
+  (and-type)
+  (or-type)
+  (not-type)
+  (xor-type))
+
+(define-datatype input_list input_list?
+  (empty-input_list)
+  (bool-input_list
+   (bool boolean?)
+   (rest input_list?))
+  (gateref-input_list
+   (gateref symbol?)
+   (rest input_list?)))
+
+; examples of creation
+
+; Example 1
+(define input-list1 (gateref-input_list 'A (empty-input_list)))
+(define gate1 (a-gate 'G1 (not-type) input-list1))
+(define gate-list1 (nonempty-gate_list gate1 (empty-gate_list)))
+(define circuit1 (a-circuit gate-list1))
+
+; Display the circuit
+(write circuit1) (newline)
+
+; Example 2
+(define input-list2 (gateref-input_list 'A (gateref-input_list 'B (empty-input_list))))
+(define gate2 (a-gate 'G1 (and-type) input-list2))
+(define gate-list2 (nonempty-gate_list gate2 (empty-gate_list)))
+(define circuit2 (a-circuit gate-list2))
+
+; Display the circuit
+(write circuit2)
+(newline)
+
+; Example 3
+(define input-list3-1 (gateref-input_list 'A (gateref-input_list 'B (empty-input_list))))
+(define input-list3-2 (gateref-input_list 'G1 (empty-input_list)))
+(define gate3-1 (a-gate 'G1 (or-type) input-list3-1))
+(define gate3-2 (a-gate 'G2 (not-type) input-list3-2))
+(define gate-list3 (nonempty-gate_list gate3-1 (nonempty-gate_list gate3-2 (empty-gate_list))))
+(define circuit3 (a-circuit gate-list3))
+
+; Display the circuit
+(write circuit3)
+(newline)
+
+; Example 4
+(define input-list4-1 (gateref-input_list 'A (gateref-input_list 'B (empty-input_list))))
+(define input-list4-2 (gateref-input_list 'A (gateref-input_list 'B (empty-input_list))))
+(define input-list4-3 (gateref-input_list 'G2 (empty-input_list)))
+(define input-list4-4 (gateref-input_list 'G1 (gateref-input_list 'G3 (empty-input_list))))
+(define gate4-1 (a-gate 'G1 (or-type) input-list4-1))
+(define gate4-2 (a-gate 'G2 (and-type) input-list4-2))
+(define gate4-3 (a-gate 'G3 (not-type) input-list4-3))
+(define gate4-4 (a-gate 'G4 (and-type) input-list4-4))
+(define gate-list4 (nonempty-gate_list gate4-1 (nonempty-gate_list gate4-2 (nonempty-gate_list gate4-3 (nonempty-gate_list gate4-4 (empty-gate_list))))))
+(define circuit4 (a-circuit gate-list4))
+
+; Display the circuit
+(write circuit4)
+(newline)

--- a/second-workshop/CircuitosListas.rkt
+++ b/second-workshop/CircuitosListas.rkt
@@ -1,0 +1,110 @@
+; Gabriela Guzmán 2326772-3743
+; Valentina Sanchéz 2324754-3743
+; Juan Pablo Moreno 2372232-3743
+
+; -------------------------------------------------------------------------- ;
+;                                 BNF GRAMMAR                                ;
+; -------------------------------------------------------------------------- ;
+
+; <circuit> ::= '(circuit <gatelist>)
+; <gatelist> ::= empty | <gate> <gatelist>
+; <gate> ::= '(gate <gateid> <type> <inputlist>)
+; <gateid> ::= identificador de la compuerta
+; <type> ::= and | or | not | xor
+; <inputlist> ::= empty | <bool> <inputlist>
+;               | <gateref> <inputlist>
+; <gateref> ::= identificador de otra compuerta
+
+#lang eopl
+
+; list-based grammar implementation
+
+; constructors 
+
+(define make-input_list (lambda input (cons 'input_list input)))
+
+(define make-type (lambda (op) (list 'type op)))
+
+(define make-gate (lambda (gateid type il) (list 'gate gateid type il)))
+
+(define make-gate_list (lambda gates (cons 'gate_list gates)))
+
+(define make-circuit (lambda (gl) (list 'circuit gl)))
+
+; extractors
+
+(define input_list->first (lambda (il) (if (null? (cdr il)) '() (cadr il))))
+
+(define input_list->rest (lambda (il) (if (null? (cdr il)) '() (cddr il))))
+
+(define gate->gate_id (lambda (gate) (cadr gate)))
+
+(define gate->type (lambda (gate) (caddr gate)))
+
+(define gate->input_list (lambda (gate) (cadddr gate)))
+
+(define gate_list->first (lambda (gl) (if (null? (cdr gl)) '() (cadr gl))))
+
+(define gate_list->rest (lambda (gl) (if (null? (cdr gl)) '() (cddr gl))))
+
+(define circuit->gate_list (lambda (circuit) (cadr circuit)))
+
+; examples of creation
+
+(display(make-circuit (make-gate_list 
+        (make-gate 'G1 (make-type 'not) (make-input_list 'A))))) (newline)
+        ; -> (circuit (gate_list (gate G1 (type not) (input_list A))))
+
+(display(make-circuit (make-gate_list 
+        (make-gate 'G1 (make-type 'and) (make-input_list 'A 'B))))) (newline)
+        ; -> (circuit (gate_list (gate G1 (type and) (input_list A B))))
+
+(display(make-circuit (make-gate_list
+        (make-gate 'G1 (make-type 'or) (make-input_list 'A 'B))
+        (make-gate 'G2 (make-type 'not) (make-input_list 'G1))))) (newline)
+        ; -> (circuit (gate_list (gate G1 (type or) (input_list A B)) (gate G2 (type not) (input_list G1))))
+
+(display(make-circuit (make-gate_list
+        (make-gate 'G1 (make-type 'or) (make-input_list 'A 'B))
+        (make-gate 'G2 (make-type 'and) (make-input_list 'A 'B))
+        (make-gate 'G3 (make-type 'not) (make-input_list 'G2))
+        (make-gate 'G4 (make-type 'and) (make-input_list 'G1 'G3))))) (newline)
+        ; -> (circuit (gate_list (gate G1 (type or) (input_list A B)) (gate G2 (type and) (input_list A B)) 
+        ; (gate G3 (type not) (input_list G2)) (gate G4 (type and) (input_list G1 G3))))
+
+; examples of use of the extractors
+
+(define a (make-circuit (make-gate_list
+        (make-gate 'G1 (make-type 'or) (make-input_list 'A 'B))
+        (make-gate 'G2 (make-type 'not) (make-input_list 'G1))
+        (make-gate 'G3 (make-type 'xor) (make-input_list 'C)))))
+
+; Extract the gate list from the circuit
+(define gate-list-of-a (circuit->gate_list a))
+
+(display gate-list-of-a) (newline) ; (gate_list (gate G1 (type or) (input_list A B)) (gate G2 (type and) (input_list A B)) 
+                                   ; (gate G3 (type xor) (input_list C)))
+
+; Get the first gate from the gate list
+(define first-gate (gate_list->first gate-list-of-a))
+
+(display first-gate) (newline) ; -> (gate G1 (type or) (input_list A B))
+
+; Get the rest of the gate list
+(define rest-gate (gate_list->rest gate-list-of-a))
+
+(display rest-gate) (newline) ; -> ((gate G2 (type not) (input_list G1)) (gate G3 (type xor) (input_list C)))
+
+; Get the information of the first gate
+(display (gate->gate_id first-gate)) (newline); -> G1
+
+(display (gate->type first-gate)) (newline) ; -> (type or)
+
+(display (gate->input_list first-gate)) (newline) ; -> (input_list A B)
+
+; Get the first and last of the input list for the first gate
+(define input-list-of-first-gate (gate->input_list first-gate))
+
+(display (input_list->first input-list-of-first-gate)) (newline) ; -> A
+
+(display (input_list->rest input-list-of-first-gate)) (newline) ; -> (B)

--- a/second-workshop/ParseUnparse.rkt
+++ b/second-workshop/ParseUnparse.rkt
@@ -1,0 +1,94 @@
+#lang eopl
+
+; Gabriela Guzmán 2326772-3743
+; Valentina Sanchéz 2324754-3743
+; Juan Pablo Moreno 2372232-3743
+
+; -------------------------------------------------------------------------- ;
+;                                 BNF GRAMMAR                                ;
+; -------------------------------------------------------------------------- ;
+
+; <circuit> ::= '(circuit <gatelist>)
+; <gatelist> ::= empty | <gate> <gatelist>
+; <gate> ::= '(gate <gateid> <type> <inputlist>)
+; <gateid> ::= identificador de la compuerta
+; <type> ::= and | or | not | xor
+; <inputlist> ::= empty | <bool> <inputlist>
+;               | <gateref> <inputlist>
+; <gateref> ::= identificador de otra compuerta
+
+(define-datatype circuit circuit?
+  (a-circuit
+   (gate_list gate_list?)))
+
+(define-datatype gate_list gate_list?
+  (empty-gate_list)
+  (nonempty-gate_list
+   (gate gate?)
+   (rest gate_list?)))
+
+(define-datatype gate gate?
+  (a-gate (gate_id symbol?)
+          (type type?)
+          (input_list input_list?)))
+
+(define-datatype type type?
+  (and-type)
+  (or-type)
+  (not-type)
+  (xor-type))
+
+(define-datatype input_list input_list?
+  (empty-input_list)
+  (bool-input_list
+   (bool boolean?)
+   (rest input_list?))
+  (gateref-input_list
+   (gateref symbol?)
+   (rest input_list?)))
+
+
+;(define PARSEBNF 
+;  (lambda (codigo)
+;    (cond
+;    
+;    [(eqv? (car codigo) 'circuit) (circuit (cadr codigo) (PARSEBNF (caadr codigo)))]
+    ;()
+    ;()
+;    (else 'estamalescrito)
+    
+;    )))
+
+;(parsebnf '(circuit (gate_list (gate G1 (type not) (input_list #t)))))
+
+
+
+(define (PARSEBNF datum)
+  (let ((gate-list (cadr datum)))  ; Extraemos la lista de compuertas
+    (a-circuit (parse-gate-list (cdr gate-list)))))  ; Convertimos a `gate_list`
+
+(define (parse-gate-list lst)
+  (if (null? lst) 
+      (empty-gate_list)  ; Lista vacía -> `empty-gate_list`
+      (nonempty-gate_list 
+       (parse-gate (car lst))  ; Convertimos el primer `gate`
+       (parse-gate-list (cdr lst)))))  ; Recursión para el resto
+
+(define (parse-gate lst)
+  (a-gate (cadr lst)  ; `gate_id`
+          (parse-type (cadr (caddr lst)))  ; Convertimos el tipo
+          (parse-input-list (cadddr lst))))  ; Convertimos `input_list`
+
+(define (parse-type type)
+  (case type
+    [(and) (and-type)]
+    [(or) (or-type)]
+    [(not) (not-type)]
+    [(xor) (xor-type)]))
+
+(define (parse-input-list lst)
+  (if (null? lst) 
+      (empty-input_list)  ; `empty-input_list`
+      (if (boolean? (car lst))  ; Booleano -> `bool-input_list`
+          (bool-input_list (car lst) (parse-input-list (cdr lst)))
+          (gateref-input_list (car lst) (parse-input-list (cdr lst))))))  ; Identificador -> `gateref-input_list`

--- a/second-workshop/ParseUnparse.rkt
+++ b/second-workshop/ParseUnparse.rkt
@@ -48,18 +48,9 @@
    (rest input_list?)))
 
 
-;(define PARSEBNF 
-;  (lambda (codigo)
-;    (cond
-;    
-;    [(eqv? (car codigo) 'circuit) (circuit (cadr codigo) (PARSEBNF (caadr codigo)))]
-    ;()
-    ;()
-;    (else 'estamalescrito)
-    
-;    )))
-
-;(parsebnf '(circuit (gate_list (gate G1 (type not) (input_list #t)))))
+; -------------------------------------------------------------------------- ;
+;                               PARSEADOR BNF                                ;
+; -------------------------------------------------------------------------- ;
 
 (define (PARSEBNF datum)
   (let ((gate-list (cadr datum)))  ; Extraemos la lista de compuertas
@@ -90,6 +81,24 @@
       (if (boolean? (car lst))  ; Booleano -> `bool-input_list`
           (bool-input_list (car lst) (parse-input-list (cdr lst)))
           (gateref-input_list (car lst) (parse-input-list (cdr lst))))))  ; Identificador -> `gateref-input_list`
+
+; -------------------------------------------------------------------------- ;
+;                               EJEMPLOS DE PRUEBA                           ;
+; -------------------------------------------------------------------------- ;
+
+(display " Ejemplo de prueba 1 ---")
+(newline)
+(display (PARSEBNF '(CIRCUIT (gate_list (gate G1 (type not) (input_list #t))))))
+(newline)
+(display "Ejemplo de prueba 2 ---")
+(newline)
+(display (PARSEBNF '(circuit (gate_list (gate G1 (type and) (input_list A B))))))
+(newline)
+
+; -------------------------------------------------------------------------- ;
+;                               UNPARSEADOR BNF                              ;
+; -------------------------------------------------------------------------- ;
+
 
 ;; Convierte un árbol de sintaxis abstracta (circuito) a su representación en listas
 (define UNPARSEBNF
@@ -128,7 +137,10 @@
     (bool-input_list (value next) (cons value (UNPARSEBNF-inputs next)))  ;; Entrada booleana
     (gateref-input_list (ref next) (cons ref (UNPARSEBNF-inputs next))))) ;; Referencia a otra compuerta
 
-;; Prueba de UNPARSEBNF
+; -------------------------------------------------------------------------- ;
+;                               EJEMPLOS DE PRUEBA UNPARSE                   ;
+; -------------------------------------------------------------------------- ;
+
 (define circuit-ejemplo
   (a-circuit
    (nonempty-gate_list
@@ -137,4 +149,5 @@
     (empty-gate_list))))
 
 ;; Muestra el resultado de la conversión de un circuito a listas
+(display "Ejemplo de prueba 1 UNPARSE")
 (display (UNPARSEBNF circuit-ejemplo)) (newline)


### PR DESCRIPTION
This pull request includes the addition of the directory with the necessary files for the second workshop, which evaluates data abstraction and abstract syntax.  

The requirement for this workshop was the implementation of the following grammar, which defines logical circuits using a BNF representation:

![image](https://github.com/user-attachments/assets/fd1eee33-d317-4167-8958-34ccc9caab63)

This workshop required the implementation of three files:  

#### 1. `CircuitosListas.rkt`  
This file contains the implementation of the circuit grammar using lists. It includes constructors and extractors for circuits, gates, and input lists, following the given BNF grammar. Additionally, it provides test cases demonstrating its correct functionality.  

#### 2. `CircuitosDT.rkt`  
This file presents an alternative implementation using datatypes. It structures the circuit representation using Racket's datatype system, providing a different way to manipulate logical circuits. The file includes example cases similar to the list-based implementation.  

#### 3. `ParseUnparse.rkt`  
This file contains the implementation of two main functions:  
- **`PARSEBNF`**: Converts a list-based concrete representation of a circuit into an abstract syntax tree using datatypes.  
- **`UNPARSEBNF`**: Converts the abstract syntax tree back into its concrete list-based representation.  

All implementations include documentation and test cases to verify correctness.
